### PR TITLE
improvement: Add compatibility with Azure Secret (aka USSec) region.

### DIFF
--- a/azuresdk/README.md
+++ b/azuresdk/README.md
@@ -49,13 +49,13 @@ Following environment variables needs to be set (automatically set via workloadi
 
 ### Azure Cloud/Environment support
 
-| `AZURE_ENVIRONMENT`                                               | Description                                                                                  |
-|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| `AzurePublicCloud`, `AzurePublic`, `AzureCloud`                   | Default Azure cloud, using https://portal.azure.com                                          |
-| `AzureChinaCloud`, `AzureChina`                                   | Azure cloud in China, using https://porta.azure.cn                                           |
-| `AzureGovernmentCloud`, `AzureGoverment`, `AzureUSGovermentCloud` | US Government Azure cloud                                                                    |
-| `AzureSecretCloud`, `AzureSecret`, `USSec`                        | Azure Secret Cloud region, needs additional configuration for endpoints                      |
-| `AzurePrivateCloud`, `AzurePrivate`                               | Private on-premise installation of Azure Cloud, needs additional configuration for endpoints |
+| `AZURE_ENVIRONMENT`                                                        | Description                                                                                  |
+|----------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| `AzurePublicCloud`, `AzurePublic`, `AzureCloud`                            | Default Azure cloud, using https://portal.azure.com                                          |
+| `AzureChinaCloud`, `AzureChina`                                            | Azure cloud in China, using https://porta.azure.cn                                           |
+| `AzureGovernmentCloud`, `AzureGoverment`, `AzureUSGovermentCloud`, `USGov` | US Government Azure cloud                                                                    |
+| `AzureSecretCloud`, `AzureSecret`, `USSec`                                 | Azure Secret Cloud region, needs additional configuration for endpoints                      |
+| `AzurePrivateCloud`, `AzurePrivate`                                        | Private on-premise installation of Azure Cloud, needs additional configuration for endpoints |
 
 #### Azure Private cloud
 

--- a/azuresdk/README.md
+++ b/azuresdk/README.md
@@ -49,12 +49,13 @@ Following environment variables needs to be set (automatically set via workloadi
 
 ### Azure Cloud/Environment support
 
-| `AZURE_ENVIRONMENT`    | Description                                                                                  |
-|------------------------|----------------------------------------------------------------------------------------------|
-| `AzurePublicCloud`     | Default Azure cloud, using https://portal.azure.com                                          |
-| `AzureChinaCloud`      | Azure cloud in China, using https://porta.azure.cn                                           |
-| `AzureGovernmentCloud` | US Government Azure cloud                                                                    |
-| `AzurePrivateCloud`    | Private on-premise installation of Azure Cloud, needs additional configuration for endpoints |
+| `AZURE_ENVIRONMENT`                                               | Description                                                                                  |
+|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| `AzurePublicCloud`, `AzurePublic`, `AzureCloud`                   | Default Azure cloud, using https://portal.azure.com                                          |
+| `AzureChinaCloud`, `AzureChina`                                   | Azure cloud in China, using https://porta.azure.cn                                           |
+| `AzureGovernmentCloud`, `AzureGoverment`, `AzureUSGovermentCloud` | US Government Azure cloud                                                                    |
+| `AzureSecretCloud`, `AzureSecret`, `USSec`                        | Azure Secret Cloud region, needs additional configuration for endpoints                      |
+| `AzurePrivateCloud`, `AzurePrivate`                               | Private on-premise installation of Azure Cloud, needs additional configuration for endpoints |
 
 #### Azure Private cloud
 

--- a/azuresdk/cloudconfig/cloudconfig.go
+++ b/azuresdk/cloudconfig/cloudconfig.go
@@ -121,17 +121,17 @@ func getAzureCloudConfig() (cloud.Configuration, error) {
 		// cloud config via JSON file
 		data, err := os.ReadFile(val) // #nosec G304
 		if err != nil {
-			return cloudConfig, fmt.Errorf(`unable to parse json for USSec/AzurePrivateCloud from env var AZURE_CLOUD_CONFIG_FILE, see https://github.com/webdevops/go-common/tree/main/azuresdk: %w`, err)
+			return cloudConfig, fmt.Errorf(`unable to parse json for AzureSecretCloud/AzurePrivateCloud from env var AZURE_CLOUD_CONFIG_FILE, see https://github.com/webdevops/go-common/tree/main/azuresdk: %w`, err)
 		}
 		cloudConfigJson = data
 	}
 
 	if len(cloudConfigJson) == 0 {
-		return cloudConfig, fmt.Errorf(`USSec/AzurePrivateCloud needs cloudconfig json passed via env var AZURE_CLOUD_CONFIG or AZURE_CLOUD_CONFIG_FILE, see https://github.com/webdevops/go-common/tree/main/azuresdk`)
+		return cloudConfig, fmt.Errorf(`AzureSecretCloud/AzurePrivateCloud needs cloudconfig json passed via env var AZURE_CLOUD_CONFIG or AZURE_CLOUD_CONFIG_FILE, see https://github.com/webdevops/go-common/tree/main/azuresdk`)
 	}
 
 	if err := json.Unmarshal([]byte(cloudConfigJson), &cloudConfig); err != nil {
-		return cloudConfig, fmt.Errorf(`unable to parse json for USSec/AzurePrivateCloud from env var AZURE_CLOUD_CONFIG or AZURE_CLOUD_CONFIG_FILE, see https://github.com/webdevops/go-common/tree/main/azuresdk: %w`, err)
+		return cloudConfig, fmt.Errorf(`unable to parse json for AzureSecretCloud/AzurePrivateCloud from env var AZURE_CLOUD_CONFIG or AZURE_CLOUD_CONFIG_FILE, see https://github.com/webdevops/go-common/tree/main/azuresdk: %w`, err)
 	}
 
 	return cloudConfig, nil

--- a/azuresdk/cloudconfig/cloudconfig.go
+++ b/azuresdk/cloudconfig/cloudconfig.go
@@ -53,7 +53,7 @@ func NewCloudConfig(cloudName string) (config CloudEnvironment, err error) {
 
 	// ----------------------------------------------------
 	// Azure Government cloud
-	case "azuregovernment", "azuregovernmentcloud", "azureusgovernmentcloud":
+	case "usgov", "azuregovernment", "azuregovernmentcloud", "azureusgovernmentcloud":
 		config, err = CloudEnvironment{
 			Name:          AzureGovernmentCloud,
 			Configuration: cloud.AzureGovernment,

--- a/azuresdk/cloudconfig/consts.go
+++ b/azuresdk/cloudconfig/consts.go
@@ -13,6 +13,7 @@ const (
 	AzurePublicCloud     = CloudName("AzurePublicCloud")
 	AzureChinaCloud      = CloudName("AzureChinaCloud")
 	AzureGovernmentCloud = CloudName("AzureGovernmentCloud")
+	AzureSecretCloud     = CloudName("AzureSecretCloud")
 	AzurePrivateCloud    = CloudName("AzurePrivateCloud")
 
 	// Service name


### PR DESCRIPTION
## Problem

This go-common is used by https://github.com/webdevops/azure-metrics-exporter in order to collect metrics from azure and make them available to Prometheus. Today this wrapper around the azure sdk does not support Azure's secret region.

https://azure.microsoft.com/en-us/explore/global-infrastructure/government/national-security

## Proposal

This PR attempts to add preliminary support for the secret region. I can't share the exact endpoints but in effort to support this new region we can reuse some functionality already present in this repo for reading in secret endpoints via the AZURE_CLOUD_CONFIG envvar. 

Adds support for interpreting azure secret cloud from the AZURE_ENVIRONMENT variable. When using the secret cloud region you will need to additionally pass in AZURE_CLOUD_CONFIG similar to private azure cloud since the secret region endpoints themselves are considered PROPIN by Microsoft.

## Notes for reviewer
This only adds support for the Azure secret region. There is a TS region as well but i'm purposefully leaving that out of this PR for now since I'm not sure what the AZURE_ENVIRONMENT envvar for this region is expected to be myself yet. 
https://azure.microsoft.com/en-us/blog/azure-government-top-secret-now-generally-available-for-us-national-security-missions/