### PR TITLE
fix HashedMetricList when supplying multiple labels

### DIFF
--- a/prometheus/hashed_metric_list.go
+++ b/prometheus/hashed_metric_list.go
@@ -3,6 +3,8 @@ package prometheus
 import (
 	"crypto/sha256"
 	"fmt"
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -80,8 +82,8 @@ func (m *HashedMetricList) Inc(labels prometheus.Labels) {
 	defer m.mux.Unlock()
 
 	metricKey := ""
-	for key, value := range labels {
-		metricKey = metricKey + key + "=" + value + ";"
+	for _, key := range slices.Sorted(maps.Keys(labels)) {
+		metricKey = metricKey + key + "=" + labels[key] + ";"
 	}
 	hashKey := fmt.Sprintf("%x", sha256.Sum256([]byte(metricKey)))
 	if _, exists := m.List[hashKey]; exists {

--- a/prometheus/hashed_metrics_list_test.go
+++ b/prometheus/hashed_metrics_list_test.go
@@ -14,25 +14,25 @@ func Test_HashedMetricsList(t *testing.T) {
 
 func hashedMetricsListGenerateMetrics(t *testing.T, m *HashedMetricList) {
 	expectHashedListCount(t, m, 0)
-	m.Inc(prometheus.Labels{"key": "info"})
+	m.Inc(prometheus.Labels{"key": "info", "foo": "bar"})
 	expectHashedListCount(t, m, 1)
 
-	m.Inc(prometheus.Labels{"key": "info"})
+	m.Inc(prometheus.Labels{"key": "info", "foo": "bar"})
 	expectHashedListCount(t, m, 1)
 
-	m.Inc(prometheus.Labels{"key": "test"})
+	m.Inc(prometheus.Labels{"key": "test", "foo": "bar"})
 	expectHashedListCount(t, m, 2)
 
-	m.Inc(prometheus.Labels{"key": "info"})
+	m.Inc(prometheus.Labels{"key": "info", "foo": "bar"})
 	expectHashedListCount(t, m, 2)
 
-	m.Inc(prometheus.Labels{"key": "test"})
+	m.Inc(prometheus.Labels{"key": "test", "foo": "bar"})
 	expectHashedListCount(t, m, 2)
 
-	m.Inc(prometheus.Labels{"key": "test2"})
+	m.Inc(prometheus.Labels{"key": "test2", "foo": "bar"})
 	expectHashedListCount(t, m, 3)
 
-	m.Inc(prometheus.Labels{"key": "info"})
+	m.Inc(prometheus.Labels{"key": "info", "foo": "bar"})
 	expectHashedListCount(t, m, 3)
 }
 


### PR DESCRIPTION
Because the order of a map in Go is not deterministic, doing:

```go
m1 := map[string]string {
  "1": "a",
  "2": "b"
}
m2 := map[string]string {
  "1": "a",
  "2": "b"
}

for k, v := range m1 {
  fmt.Println(k, v)
}

for k, v := range m2 {
  fmt.Println(k, v)
}
```

Does not necessarily yield the same result:
<img width="415" alt="image" src="https://github.com/user-attachments/assets/0cd88111-c300-43fd-b104-8ea5840d2deb" />
_(From Go Playground)_